### PR TITLE
Fix apr-iconv build with Visual Studio 2013 (and earlier?).

### DIFF
--- a/build/modules.mk.win
+++ b/build/modules.mk.win
@@ -218,7 +218,7 @@ $(MODRES).pch:
 
 .c{$(OUTPUT_DIR)}.so:
 	$(SILENT)cl $(ALL_CFLAGS) /Fo$*.obj /Yuiconv.h /c $<
-	$(SILENT)link $(ALL_LDFLAGS) $*.obj $(API_LIBS) /out:$@ \
+	$(SILENT)link $(ALL_LDFLAGS) $*.obj $(MODRES).obj $(API_LIBS) /out:$@ \
 		/base:@"..\build\BaseAddr.ref",$(@F)
 	$(SILENT)if exist $@.manifest \
 		$(SILENT)mt -nologo -manifest $@.manifest -outputresource:$@;2 \


### PR DESCRIPTION
The error without the patch is:

adobe-stdenc.obj : error LNK2011: precompiled object not linked in; image may not run
